### PR TITLE
Explore/Home Screen (without infinite scroll)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-lib-report": "^3.0.3",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/stack-utils": "^2.0.3",
+        "@types/yargs": "^17.0.32",
         "aws-sdk": "^2.1516.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.6",
@@ -784,6 +789,27 @@
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.5.tgz",
@@ -869,6 +895,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
+    },
     "node_modules/@types/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -885,6 +916,19 @@
       "version": "13.11.6",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.6.tgz",
       "integrity": "sha512-HUgHujPhKuNzgNXBRZKYexwoG+gHKU+tnfPqjWXFghZAnn73JElicMkuSKJyLGr9JgyA8IgK7fj88IyA9rwYeQ=="
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
     "node_modules/abbrev": {
       "version": "2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,11 @@
   },
   "license": "ISC",
   "dependencies": {
+    "@types/istanbul-lib-coverage": "^2.0.6",
+    "@types/istanbul-lib-report": "^3.0.3",
+    "@types/istanbul-reports": "^3.0.4",
+    "@types/stack-utils": "^2.0.3",
+    "@types/yargs": "^17.0.32",
     "aws-sdk": "^2.1516.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -38,13 +38,15 @@
         "react-native-web": "~0.19.6",
         "react-navigation-collapsible": "^6.3.0",
         "react-redux": "^9.1.0",
-        "redux-logger": "^3.0.6"
+        "redux-logger": "^3.0.6",
+        "yup": "^1.3.3"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
         "@types/react": "~18.2.45",
         "@types/redux-logger": "^3.0.13",
         "@types/uuid": "^9.0.8",
+        "concurrently": "^8.2.2",
         "typescript": "^5.1.3"
       }
     },
@@ -8784,6 +8786,118 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concurrently/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/connect": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -8957,6 +9071,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
       "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.10",
@@ -13190,6 +13320,11 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -13990,6 +14125,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -14278,6 +14422,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
     },
     "node_modules/split": {
       "version": "1.0.1",
@@ -14775,6 +14925,11 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14818,6 +14973,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -14832,6 +14992,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -15366,6 +15535,28 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.3.3.tgz",
+      "integrity": "sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -40,13 +40,15 @@
     "react-native-web": "~0.19.6",
     "react-navigation-collapsible": "^6.3.0",
     "react-redux": "^9.1.0",
-    "redux-logger": "^3.0.6"
+    "redux-logger": "^3.0.6",
+    "yup": "^1.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",
     "@types/react": "~18.2.45",
     "@types/redux-logger": "^3.0.13",
     "@types/uuid": "^9.0.8",
+    "concurrently": "^8.2.2",
     "typescript": "^5.1.3"
   },
   "private": true

--- a/mobile/screens/Home/Components/Search.tsx
+++ b/mobile/screens/Home/Components/Search.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+
+
+const Search:React.FC = () => {
+    // const [searchInput, setSearchInput] = useState("")
+
+    // const handleInputChange = (input: string) => {
+    //     setSearchInput(input);
+    // };
+
+  return (
+    <SafeAreaView >
+        <View style={styles.searchBarContainer}>
+            <TouchableOpacity style={styles.searchBar}>
+            <Text style={styles.placeholderHeading}>Where To?</Text>
+            <Text style={styles.placeholderSubheading}>Anywhere · Any week · Add guests</Text>
+            </TouchableOpacity>
+         
+
+
+      {/* <SearchBar
+        platform='ios'
+        placeholder='Where to?'
+        value={searchInput} 
+        onBlur={undefined} 
+        onChangeText={handleInputChange} 
+        onFocus={undefined} 
+        clearIcon={false}
+        searchIcon={{ name: 'search' }} 
+        loadingProps={undefined} 
+        showLoading={false} 
+        onClear={undefined} 
+        onCancel={undefined} 
+        lightTheme={false} 
+        round={true} 
+        cancelButtonTitle={''} 
+        cancelButtonProps={undefined} 
+        showCancel={false}
+        // style={{backgroundColor:'red'}}     
+        />
+        */}
+        </View> 
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+    searchBarContainer: {
+        height: 100,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+    searchBar: {
+        backgroundColor: 'white',
+        height: 50,
+        width: 300,
+        borderColor: '#e4e4e4',
+        borderWidth: 0.4,
+        shadowColor: '#e4e4e4',
+        borderRadius: 30,
+        justifyContent:'center'
+    },
+    placeholderHeading: {
+        marginLeft: 30,
+        fontWeight: '500',
+        fontSize: 14
+    },
+    placeholderSubheading: {
+        marginLeft: 30,
+        color: '#717171',
+        fontSize: 12
+    },
+})
+
+export default Search;

--- a/mobile/screens/Home/Components/Search.tsx
+++ b/mobile/screens/Home/Components/Search.tsx
@@ -1,55 +1,33 @@
-import React, { useState } from 'react';
-import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faSearch, faFilter } from '@fortawesome/free-solid-svg-icons';
 
 
 const Search:React.FC = () => {
-    // const [searchInput, setSearchInput] = useState("")
-
-    // const handleInputChange = (input: string) => {
-    //     setSearchInput(input);
-    // };
 
   return (
-    <SafeAreaView >
         <View style={styles.searchBarComponentContainer}>
-            <TouchableOpacity style={styles.searchBar}>
-                <FontAwesomeIcon icon={faSearch} style={styles.searchIcon} size={20}/>
-                <Text style={styles.placeholderHeading}>Where To?</Text>
-                <Text style={styles.placeholderSubheading}>Anywhere · Any week · Add guests</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.filterIconContainer}>
-                <FontAwesomeIcon icon={faFilter} size={20}/>
-            </TouchableOpacity>
-   
-         
-
-
-      {/* <SearchBar
-        platform='ios'
-        placeholder='Where to?'
-        value={searchInput} 
-        onBlur={undefined} 
-        onChangeText={handleInputChange} 
-        onFocus={undefined} 
-        clearIcon={false}
-        searchIcon={{ name: 'search' }} 
-        loadingProps={undefined} 
-        showLoading={false} 
-        onClear={undefined} 
-        onCancel={undefined} 
-        lightTheme={false} 
-        round={true} 
-        cancelButtonTitle={''} 
-        cancelButtonProps={undefined} 
-        showCancel={false}
-        // style={{backgroundColor:'red'}}     
-        />
-        */}
+            <View style={styles.searchBarView}>
+                <TouchableOpacity 
+                    style={styles.searchBar}
+                    activeOpacity={0.8}
+                >
+                    <FontAwesomeIcon icon={faSearch} style={styles.searchIcon} size={20}/>
+                    <Text style={styles.placeholderHeading}>Where To?</Text>
+                    <Text style={styles.placeholderSubheading}>Anywhere · Any week · Add guests</Text>
+                </TouchableOpacity>
+            </View>
+            <View style={styles.filterIconView}>
+                <TouchableOpacity 
+                    style={styles.filterIconContainer}
+                    activeOpacity={0.9}
+                >
+                    <FontAwesomeIcon icon={faFilter} size={20}/>
+                </TouchableOpacity>
+            </View>
         </View> 
-    </SafeAreaView>
   );
 }
 
@@ -62,16 +40,19 @@ const styles = StyleSheet.create({
         borderBottomWidth: 1
         // alignItems: 'center'
     },
+    searchBarView: {
+        width: 320,
+        marginLeft: 25,
+        borderRadius: 30,
+    },
     searchBar: {
         backgroundColor: 'white',
         height: 50,
         width: 320,
         borderColor: '#e4e4e4',
         borderWidth: 0.4,
-        shadowColor: '#e4e4e4',
         borderRadius: 30,
         justifyContent:'center',
-        marginLeft: 25
     },
     placeholderHeading: {
         marginLeft: 60,
@@ -89,15 +70,21 @@ const styles = StyleSheet.create({
         position: 'absolute',
         marginLeft: 20
     },
+    filterIconView: {
+        width: 40,
+        height: 40,
+        position: 'absolute',
+        left: 360,
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: 30,
+    },
     filterIconContainer: {
         width: 40,
         height: 40,
         borderColor: '#b8b8b8',
         borderWidth: 1.5,
         borderRadius: 30,
-        position: 'absolute',
-        left: 360,
-        bottom: 5,
         justifyContent: 'center',
         alignItems: 'center'
     },

--- a/mobile/screens/Home/Components/Search.tsx
+++ b/mobile/screens/Home/Components/Search.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import { TouchableOpacity } from 'react-native-gesture-handler';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+
 
 
 const Search:React.FC = () => {
@@ -15,9 +17,11 @@ const Search:React.FC = () => {
     <SafeAreaView >
         <View style={styles.searchBarContainer}>
             <TouchableOpacity style={styles.searchBar}>
-            <Text style={styles.placeholderHeading}>Where To?</Text>
-            <Text style={styles.placeholderSubheading}>Anywhere · Any week · Add guests</Text>
+                <FontAwesomeIcon icon={faSearch} style={styles.searchIcon} size={20}/>
+                <Text style={styles.placeholderHeading}>Where To?</Text>
+                <Text style={styles.placeholderSubheading}>Anywhere · Any week · Add guests</Text>
             </TouchableOpacity>
+   
          
 
 
@@ -56,7 +60,7 @@ const styles = StyleSheet.create({
     searchBar: {
         backgroundColor: 'white',
         height: 50,
-        width: 300,
+        width: 350,
         borderColor: '#e4e4e4',
         borderWidth: 0.4,
         shadowColor: '#e4e4e4',
@@ -64,15 +68,21 @@ const styles = StyleSheet.create({
         justifyContent:'center'
     },
     placeholderHeading: {
-        marginLeft: 30,
+        marginLeft: 60,
         fontWeight: '500',
-        fontSize: 14
+        fontSize: 14,
+        fontFamily: 'System'
     },
     placeholderSubheading: {
-        marginLeft: 30,
+        marginLeft: 60,
         color: '#717171',
-        fontSize: 12
+        fontSize: 12,
+        fontFamily: 'System'
     },
+    searchIcon: {
+        position: 'absolute',
+        marginLeft: 20
+    }
 })
 
 export default Search;

--- a/mobile/screens/Home/Components/Search.tsx
+++ b/mobile/screens/Home/Components/Search.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faSearch, faFilter } from '@fortawesome/free-solid-svg-icons';
+import { fonts } from '../../../constants/stylings/styles';
 
 
 const Search:React.FC = () => {
@@ -53,16 +54,13 @@ const styles = StyleSheet.create({
         justifyContent:'center',
     },
     placeholderHeading: {
-        marginLeft: 60,
+        ...fonts.defaultText,
         fontWeight: '500',
-        fontSize: 14,
-        fontFamily: 'System'
+        marginLeft: 60,
     },
     placeholderSubheading: {
-        marginLeft: 60,
-        color: '#717171',
-        fontSize: 12,
-        fontFamily: 'System'
+        ...fonts.subText,
+        marginLeft: 60, 
     },
     searchIcon: {
         position: 'absolute',

--- a/mobile/screens/Home/Components/Search.tsx
+++ b/mobile/screens/Home/Components/Search.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-
+import { faSearch, faFilter } from '@fortawesome/free-solid-svg-icons';
 
 
 const Search:React.FC = () => {
@@ -15,11 +14,14 @@ const Search:React.FC = () => {
 
   return (
     <SafeAreaView >
-        <View style={styles.searchBarContainer}>
+        <View style={styles.searchBarComponentContainer}>
             <TouchableOpacity style={styles.searchBar}>
                 <FontAwesomeIcon icon={faSearch} style={styles.searchIcon} size={20}/>
                 <Text style={styles.placeholderHeading}>Where To?</Text>
                 <Text style={styles.placeholderSubheading}>Anywhere · Any week · Add guests</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.filterIconContainer}>
+                <FontAwesomeIcon icon={faFilter} size={20}/>
             </TouchableOpacity>
    
          
@@ -52,20 +54,24 @@ const Search:React.FC = () => {
 }
 
 const styles = StyleSheet.create({
-    searchBarContainer: {
+    searchBarComponentContainer: {
         height: 100,
         justifyContent: 'center',
-        alignItems: 'center'
+        borderBottomColor: '#e2e2e2',
+        shadowColor: '#cecece',
+        borderBottomWidth: 1
+        // alignItems: 'center'
     },
     searchBar: {
         backgroundColor: 'white',
         height: 50,
-        width: 350,
+        width: 320,
         borderColor: '#e4e4e4',
         borderWidth: 0.4,
         shadowColor: '#e4e4e4',
         borderRadius: 30,
-        justifyContent:'center'
+        justifyContent:'center',
+        marginLeft: 25
     },
     placeholderHeading: {
         marginLeft: 60,
@@ -82,7 +88,19 @@ const styles = StyleSheet.create({
     searchIcon: {
         position: 'absolute',
         marginLeft: 20
-    }
+    },
+    filterIconContainer: {
+        width: 40,
+        height: 40,
+        borderColor: '#b8b8b8',
+        borderWidth: 1.5,
+        borderRadius: 30,
+        position: 'absolute',
+        left: 360,
+        bottom: 5,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
 })
 
 export default Search;

--- a/mobile/screens/Home/Components/Search.tsx
+++ b/mobile/screens/Home/Components/Search.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faSearch, faFilter } from '@fortawesome/free-solid-svg-icons';
 
@@ -36,7 +35,6 @@ const styles = StyleSheet.create({
         height: 100,
         justifyContent: 'center',
         borderBottomColor: '#e2e2e2',
-        shadowColor: '#cecece',
         borderBottomWidth: 1
         // alignItems: 'center'
     },

--- a/mobile/screens/Home/Components/SpotDetails.tsx
+++ b/mobile/screens/Home/Components/SpotDetails.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import { Spot } from '../../../typings/redux';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faStar } from '@fortawesome/free-solid-svg-icons';
+import { fonts } from '../../../constants/stylings/styles'
 
 interface ISpotDetails {
     spot: Spot
@@ -13,12 +14,12 @@ const SpotDetails:React.FC<ISpotDetails> = ({spot}) => {
     return (
     <View style={styles.spotDetailsView}>
         <View style={styles.spotDetailsContainer}>
-            <Text>{spot.city}, {spot.state}</Text>
-            <Text>Feb 7 - 12</Text>
-            <Text>${spot.price} <Text>night</Text></Text>
+            <Text style={styles.locationText}>{spot.city}, {spot.state}</Text>
+            <Text style={styles.dateText}>Feb 7 - 12</Text>
+            <Text style={[styles.priceText, {fontWeight:'600'}]}>${spot.price} <Text style={{fontWeight: '400'}}>night</Text></Text>
         </View>
-        <View style={styles.rating}>
-            <Text><FontAwesomeIcon icon={faStar}/> {spot.avgRating}</Text>
+        <View>
+            <Text style={styles.ratingText}><FontAwesomeIcon icon={faStar}/> {spot.avgRating}</Text>
         </View>
     </View>
     );
@@ -34,7 +35,19 @@ const styles = StyleSheet.create({
     spotDetailsContainer: {
         height: 75,
     },
-    rating: {
+    locationText: {
+        ...fonts.subHeader
+    },
+    dateText: {
+        ...fonts.subHeader,
+        color: '#505050'
+    },
+    ratingText: {
+        ...fonts.subHeader,
+        fontWeight: '400'
+    },
+    priceText: {
+        ...fonts.subHeader,
     }
 })
 

--- a/mobile/screens/Home/Components/SpotDetails.tsx
+++ b/mobile/screens/Home/Components/SpotDetails.tsx
@@ -15,6 +15,7 @@ const SpotDetails:React.FC<ISpotDetails> = ({spot}) => {
     <View style={styles.spotDetailsView}>
         <View style={styles.spotDetailsContainer}>
             <Text style={styles.locationText}>{spot.city}, {spot.state}</Text>
+            <Text style={styles.nameText}>{spot.name}</Text>
             <Text style={styles.dateText}>Feb 7 - 12</Text>
             <Text style={[styles.priceText, {fontWeight:'600'}]}>${spot.price} <Text style={{fontWeight: '400'}}>night</Text></Text>
         </View>
@@ -37,6 +38,10 @@ const styles = StyleSheet.create({
     },
     locationText: {
         ...fonts.subHeader
+    },
+    nameText: {
+        ...fonts.subHeader,
+        color: '#505050'
     },
     dateText: {
         ...fonts.subHeader,

--- a/mobile/screens/Home/Components/SpotDetails.tsx
+++ b/mobile/screens/Home/Components/SpotDetails.tsx
@@ -26,19 +26,41 @@ const SpotDetails:React.FC<ISpotDetails> = ({spot}) => {
 
 const styles = StyleSheet.create({
     spotDetailsView: {
-        // backgroundColor: 'pink',
         flexDirection: 'row',
         justifyContent: 'space-between',
         width: 375,
         marginTop: 10
     },
     spotDetailsContainer: {
-        // backgroundColor: 'blue',
         height: 75,
     },
     rating: {
-        // backgroundColor: 'green'
     }
 })
 
 export default SpotDetails;
+
+/*
+[
+"address": "71720 Laron Plains",
+"avgRating": "NEW",
+"city": "Dublin",
+"country": "United States",
+"createdAt": "2024-1-6",
+"description": "Great place to stay when you want to get away from it all",
+"id": 20,
+"lat": "-41.946337",
+"lng": "-29.062167",
+"name": "Cuban-style home",
+"ownerId": 3, "previewImage":
+"https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg",
+"price": 62,
+"reviews": [],
+"state":
+"Wisconsin",
+"updatedAt":
+"2024-1-6",
+"userId": 3}
+]
+
+*/

--- a/mobile/screens/Home/Components/SpotDetails.tsx
+++ b/mobile/screens/Home/Components/SpotDetails.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Spot } from '../../../typings/redux';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+
+interface ISpotDetails {
+    spot: Spot
+}
+
+
+const SpotDetails:React.FC<ISpotDetails> = ({spot}) => {
+    return (
+    <View style={styles.spotDetailsView}>
+        <View style={styles.spotDetailsContainer}>
+            <Text>{spot.city}, {spot.state}</Text>
+            <Text>Feb 7 - 12</Text>
+            <Text>${spot.price} <Text>night</Text></Text>
+        </View>
+        <View style={styles.rating}>
+            <Text><FontAwesomeIcon icon={faStar}/> {spot.avgRating}</Text>
+        </View>
+    </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    spotDetailsView: {
+        // backgroundColor: 'pink',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        width: 375,
+        marginTop: 10
+    },
+    spotDetailsContainer: {
+        // backgroundColor: 'blue',
+        height: 75,
+    },
+    rating: {
+        // backgroundColor: 'green'
+    }
+})
+
+export default SpotDetails;

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -1,25 +1,28 @@
 import React, {useEffect, useState} from 'react';
 import { useAppDispatch, useAppSelector } from '../../../store';
-import { View, ScrollView, Image, Pressable, StyleSheet } from 'react-native';
+import { View, ScrollView, Image, Text, Pressable, StyleSheet } from 'react-native';
 import { fetchSpots } from '../../../store/spots';
 import SpotDetails from '../../Home/Components/SpotDetails'
-
-
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faHeart } from '@fortawesome/free-solid-svg-icons';
+import { fonts } from '../../../constants/stylings/styles';
 
 interface IHome {
     navigation: any
 };
 
-
+interface IHeartPressed {
+    [key:number]: boolean
+}
 
 
 const Spots:React.FC<IHome> = ({navigation}) => {
     const dispatch = useAppDispatch();
     const allSpots = useAppSelector((state) => state.spots.allSpots);
-    const [isLoaded, setIsLoaded] = useState<boolean>(false);
     const date = new Date().getDate();
     const sec = new Date().getSeconds();
-
+    const [isLoaded, setIsLoaded] = useState<boolean>(false);
+    const [isHeartPressed, setIsHeartPressed] = useState<IHeartPressed>({});
 
     useEffect(() => {
         const getInfo = async() => {
@@ -29,16 +32,39 @@ const Spots:React.FC<IHome> = ({navigation}) => {
         getInfo()
     }, [isLoaded]);
 
+    const toggleHeartPress = (spotId:number) => {
+        setIsHeartPressed(prev => ({
+            ...prev,
+            [spotId]: !prev[spotId]
+        }));
+    };
+
     const goToSpotDetail = () => {
         navigation.push('SpotDetail')
     };
 
     return (
     <ScrollView>
-        {allSpots?.map((spot) => (
+        {allSpots?.map((spot, idx) => (
             <View 
-                key={`spot-${spot.id}-${date}-${sec}`}
-                style={styles.spotImageView}>
+                key={`spot-${idx}-${date}-${sec}`}
+                style={styles.spotImageView}
+            >
+            <Pressable 
+                style={styles.heartIcon}
+                onPress={() => toggleHeartPress(spot.id)}
+            >   
+                {idx % 2 === 0 && (
+                    <View style={styles.guestFavContainer}>
+                        <Text style={styles.guestFavText}>Guest favorite</Text>
+                    </View>
+                )}
+                <FontAwesomeIcon 
+                    icon={faHeart} 
+                    size={25} 
+                    color={isHeartPressed[spot.id] ? '#FF385B' :'#535350'}
+                />
+            </Pressable>
             <Pressable
                 style={styles.spotImageContainer} 
                 onPress={goToSpotDetail}
@@ -74,6 +100,26 @@ image: {
     objectFit: 'fill',
     borderRadius: 10,
     backgroundColor:'#FFFFFF',
+},
+heartIcon: {
+    position: 'absolute',
+    top: 10,
+    right: 45,
+    zIndex: 1
+},
+guestFavContainer: {
+    backgroundColor: "#FBFBFB",
+    borderColor: '#A19F9D',
+    borderRadius: 20,
+    position: 'absolute',
+    right: 220,
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 125,
+    height: 25,
+},
+guestFavText: {
+    ...fonts.subHeader
 }
 });
 

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import { useAppDispatch, useAppSelector } from '../../../store';
-import { View, Image, TouchableOpacity } from 'react-native';
+import { View, Image, TouchableOpacity, StyleSheet } from 'react-native';
 import { fetchSpots } from '../../../store/spots';
 
 
@@ -27,17 +27,44 @@ const Spots:React.FC<IHome> = ({navigation}) => {
         navigation.push('SpotDetail')
       }
 
+      console.log('data--', data)
+
       return (
         <View>
-            <TouchableOpacity onPress={goToSpotDetail}>
-                <Image 
-                style={{ width: 400, height: 400, objectFit: 'contain' }} 
-                source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}}
-                />
-            </TouchableOpacity>
- 
+            <View style={styles.spotImageView}>
+                <TouchableOpacity
+                    style={styles.spotImageContainer} 
+                    onPress={goToSpotDetail}
+                   
+                >
+                    <Image 
+                    style={styles.image} 
+                    source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}}
+                    />
+                </TouchableOpacity>
+            </View>
         </View>
       );
-    }
+    };
+
+    const styles = StyleSheet.create({
+        spotImageView: {
+            alignItems: 'center',
+            marginVertical: 20
+        },
+        spotImageContainer: {
+            backgroundColor:'green',
+            height: 265,
+            width: 400,
+            alignItems: 'center',
+            justifyContent: 'center'
+        },
+        image: {
+            width: 400,
+            height: 265,
+            objectFit: 'contain',
+            backgroundColor:'blue',
+        }
+    })
 
 export default Spots;

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -58,14 +58,15 @@ const Spots:React.FC<IHome> = ({navigation}) => {
 const styles = StyleSheet.create({
 spotImageView: {
     alignItems: 'center',
-    marginVertical: 20
+    marginTop: 20
 },
 spotImageContainer: {
     width: 375,
-    height: 425,
+    height: 460,
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 10,
+    marginBottom: 20,
 },
 image: {
     width: 375,

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -1,0 +1,43 @@
+import React, {useEffect, useState} from 'react';
+import { useAppDispatch, useAppSelector } from '../../../store';
+import { View, Image, TouchableOpacity } from 'react-native';
+import { fetchSpots } from '../../../store/spots';
+
+
+interface IHome {
+    navigation: any
+  }
+
+const Spots:React.FC<IHome> = ({navigation}) => {
+    const dispatch = useAppDispatch();
+    const data = useAppSelector((state) => state.spots.allSpots);
+    const [isLoaded, setIsLoaded] = useState<boolean>(false);
+    console.log('data--', data)
+  
+
+    useEffect(() => {
+        const getInfo = async() => {
+          await dispatch(fetchSpots())
+          setIsLoaded(true)
+        }
+        getInfo()
+      }, [isLoaded])
+
+      const goToSpotDetail = () => {
+        navigation.push('SpotDetail')
+      }
+
+      return (
+        <View>
+            <TouchableOpacity onPress={goToSpotDetail}>
+                <Image 
+                style={{ width: 400, height: 400, objectFit: 'contain' }} 
+                source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}}
+                />
+            </TouchableOpacity>
+ 
+        </View>
+      );
+    }
+
+export default Spots;

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import { useAppDispatch, useAppSelector } from '../../../store';
-import { View, Image, Pressable, StyleSheet } from 'react-native';
+import { View, ScrollView, Image, Pressable, StyleSheet } from 'react-native';
 import { fetchSpots } from '../../../store/spots';
 
 
@@ -10,9 +10,8 @@ interface IHome {
 
 const Spots:React.FC<IHome> = ({navigation}) => {
     const dispatch = useAppDispatch();
-    const data = useAppSelector((state) => state.spots.allSpots);
+    const allSpots = useAppSelector((state) => state.spots.allSpots);
     const [isLoaded, setIsLoaded] = useState<boolean>(false);
-    console.log('data--', data)
   
 
     useEffect(() => {
@@ -27,23 +26,24 @@ const Spots:React.FC<IHome> = ({navigation}) => {
         navigation.push('SpotDetail')
       }
 
-      console.log('data--', data)
+      console.log('data--', allSpots)
 
       return (
-        <View>
-            <View style={styles.spotImageView}>
+        <ScrollView>
+            {allSpots?.map((spot) => (
+                <View style={styles.spotImageView}>
                 <Pressable
                     style={styles.spotImageContainer} 
                     onPress={goToSpotDetail}
-                   
                 >
                     <Image 
                     style={styles.image} 
-                    source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}}
+                    source={{ uri: spot.previewImage}}
                     />
                 </Pressable>
             </View>
-        </View>
+            ))}
+        </ScrollView>
       );
     };
 
@@ -57,12 +57,12 @@ const Spots:React.FC<IHome> = ({navigation}) => {
             height: 375,
             alignItems: 'center',
             justifyContent: 'center',
-             borderRadius: 15,
+            borderRadius: 15,
         },
         image: {
             width: 375,
             height: 375,
-            objectFit: 'contain',
+            objectFit: 'fill',
             borderRadius: 15,
             backgroundColor:'#FFFFFF',
         }

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import { useAppDispatch, useAppSelector } from '../../../store';
-import { View, Image, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Image, Pressable, StyleSheet } from 'react-native';
 import { fetchSpots } from '../../../store/spots';
 
 
@@ -32,7 +32,7 @@ const Spots:React.FC<IHome> = ({navigation}) => {
       return (
         <View>
             <View style={styles.spotImageView}>
-                <TouchableOpacity
+                <Pressable
                     style={styles.spotImageContainer} 
                     onPress={goToSpotDetail}
                    
@@ -41,7 +41,7 @@ const Spots:React.FC<IHome> = ({navigation}) => {
                     style={styles.image} 
                     source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}}
                     />
-                </TouchableOpacity>
+                </Pressable>
             </View>
         </View>
       );
@@ -53,17 +53,18 @@ const Spots:React.FC<IHome> = ({navigation}) => {
             marginVertical: 20
         },
         spotImageContainer: {
-            backgroundColor:'green',
-            height: 265,
-            width: 400,
+            width: 375,
+            height: 375,
             alignItems: 'center',
-            justifyContent: 'center'
+            justifyContent: 'center',
+             borderRadius: 15,
         },
         image: {
-            width: 400,
-            height: 265,
+            width: 375,
+            height: 375,
             objectFit: 'contain',
-            backgroundColor:'blue',
+            borderRadius: 15,
+            backgroundColor:'#FFFFFF',
         }
     })
 

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -17,6 +17,8 @@ const Spots:React.FC<IHome> = ({navigation}) => {
     const dispatch = useAppDispatch();
     const allSpots = useAppSelector((state) => state.spots.allSpots);
     const [isLoaded, setIsLoaded] = useState<boolean>(false);
+    const date = new Date().getDate();
+    const sec = new Date().getSeconds();
 
 
     useEffect(() => {
@@ -34,7 +36,9 @@ const Spots:React.FC<IHome> = ({navigation}) => {
     return (
     <ScrollView>
         {allSpots?.map((spot) => (
-            <View style={styles.spotImageView}>
+            <View 
+                key={`spot-${spot.id}-${date}-${sec}`}
+                style={styles.spotImageView}>
             <Pressable
                 style={styles.spotImageContainer} 
                 onPress={goToSpotDetail}

--- a/mobile/screens/Home/Components/Spots.tsx
+++ b/mobile/screens/Home/Components/Spots.tsx
@@ -2,70 +2,74 @@ import React, {useEffect, useState} from 'react';
 import { useAppDispatch, useAppSelector } from '../../../store';
 import { View, ScrollView, Image, Pressable, StyleSheet } from 'react-native';
 import { fetchSpots } from '../../../store/spots';
+import SpotDetails from '../../Home/Components/SpotDetails'
+
 
 
 interface IHome {
     navigation: any
-  }
+};
+
+
+
 
 const Spots:React.FC<IHome> = ({navigation}) => {
     const dispatch = useAppDispatch();
     const allSpots = useAppSelector((state) => state.spots.allSpots);
     const [isLoaded, setIsLoaded] = useState<boolean>(false);
-  
+
 
     useEffect(() => {
         const getInfo = async() => {
-          await dispatch(fetchSpots())
-          setIsLoaded(true)
+            await dispatch(fetchSpots())
+            setIsLoaded(true)
         }
         getInfo()
-      }, [isLoaded])
+    }, [isLoaded]);
 
-      const goToSpotDetail = () => {
+    const goToSpotDetail = () => {
         navigation.push('SpotDetail')
-      }
-
-      console.log('data--', allSpots)
-
-      return (
-        <ScrollView>
-            {allSpots?.map((spot) => (
-                <View style={styles.spotImageView}>
-                <Pressable
-                    style={styles.spotImageContainer} 
-                    onPress={goToSpotDetail}
-                >
-                    <Image 
-                    style={styles.image} 
-                    source={{ uri: spot.previewImage}}
-                    />
-                </Pressable>
-            </View>
-            ))}
-        </ScrollView>
-      );
     };
 
-    const styles = StyleSheet.create({
-        spotImageView: {
-            alignItems: 'center',
-            marginVertical: 20
-        },
-        spotImageContainer: {
-            width: 375,
-            height: 375,
-            alignItems: 'center',
-            justifyContent: 'center',
-            borderRadius: 15,
-        },
-        image: {
-            width: 375,
-            height: 375,
-            objectFit: 'fill',
-            borderRadius: 15,
-            backgroundColor:'#FFFFFF',
-        }
-    })
+    return (
+    <ScrollView>
+        {allSpots?.map((spot) => (
+            <View style={styles.spotImageView}>
+            <Pressable
+                style={styles.spotImageContainer} 
+                onPress={goToSpotDetail}
+            >
+                <Image 
+                    style={styles.image} 
+                    source={{ uri: spot.previewImage}}
+                />
+                <SpotDetails spot={spot}/>
+            </Pressable>
+        </View>
+        ))}
+    </ScrollView>
+    );
+};
+
+const styles = StyleSheet.create({
+spotImageView: {
+    alignItems: 'center',
+    marginVertical: 20
+},
+spotImageContainer: {
+    width: 375,
+    height: 425,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 10,
+},
+image: {
+    width: 375,
+    height: 375,
+    objectFit: 'fill',
+    borderRadius: 10,
+    backgroundColor:'#FFFFFF',
+}
+});
 
 export default Spots;

--- a/mobile/screens/Home/Home.tsx
+++ b/mobile/screens/Home/Home.tsx
@@ -1,46 +1,15 @@
 import React from 'react';
 import { SafeAreaView, StyleSheet} from 'react-native';
-
-// import { useAppDispatch, useAppSelector } from '../../store';
-// import { fetchSpots } from '../../store/spots';
 import BottomTabs from './Components/NavBar';
 import Search from './Components/Search';
 import Spots from './Components/Spots';
-
 
 interface IHome {
   navigation: any
 }
 
+
 const Home: React.FC<IHome> = ({ navigation }) => {
-
-
-
-/*
-[
-"address": "71720 Laron Plains",
-"avgRating": "NEW",
-"city": "Dublin",
-"country": "United States",
-"createdAt": "2024-1-6",
-"description": "Great place to stay when you want to get away from it all",
-"id": 20,
-"lat": "-41.946337",
-"lng": "-29.062167",
-"name": "Cuban-style home",
-"ownerId": 3, "previewImage":
-"https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg",
-"price": 62,
-"reviews": [],
-"state":
-"Wisconsin",
-"updatedAt":
-"2024-1-6",
-"userId": 3}
-]
-
-*/
-
   return (
     <SafeAreaView style={styles.container}>
       <Search/>
@@ -53,7 +22,6 @@ const Home: React.FC<IHome> = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    // backgroundColor: 'blue'
   }
 })
 

--- a/mobile/screens/Home/Home.tsx
+++ b/mobile/screens/Home/Home.tsx
@@ -41,17 +41,10 @@ const Home: React.FC<IHome> = ({ navigation }) => {
 
 */
 
-  // console.log(isLoaded)
-// console.log(data)
-
-
-
   return (
     <SafeAreaView style={styles.container}>
       <Search/>
-      {/* <Text>This is the homepage</Text> */}
       <Spots navigation={navigation}/>
-      {/* <Image style={{ width: 400, height: 400, objectFit: 'contain' }} source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}} /> */}
       <BottomTabs navigation={navigation}/>
     </SafeAreaView>
   );

--- a/mobile/screens/Home/Home.tsx
+++ b/mobile/screens/Home/Home.tsx
@@ -1,12 +1,12 @@
-import React, {useEffect, useState} from 'react';
-import { Text, SafeAreaView, StyleSheet, Image } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
-import { useAppDispatch, useAppSelector } from '../../store';
-import { fetchSpots } from '../../store/spots';
+import React from 'react';
+import { SafeAreaView, StyleSheet} from 'react-native';
+
+// import { useAppDispatch, useAppSelector } from '../../store';
+// import { fetchSpots } from '../../store/spots';
 import BottomTabs from './Components/NavBar';
 import Search from './Components/Search';
+import Spots from './Components/Spots';
 
-// import pineapple from '../../assets/images/pineapple.jpg'
 
 interface IHome {
   navigation: any
@@ -14,23 +14,7 @@ interface IHome {
 
 const Home: React.FC<IHome> = ({ navigation }) => {
 
-  const dispatch = useAppDispatch();
-  const data = useAppSelector((state) => state.spots.allSpots);
 
-  const [isLoaded, setIsLoaded] = useState<boolean>(false);
-
-  useEffect(() => {
-    const getInfo = async() => {
-      await dispatch(fetchSpots())
-      setIsLoaded(true)
-    }
-    getInfo()
-  }, [isLoaded])
-
-
-  const goToSpotDetail = () => {
-    navigation.push('SpotDetail')
-  }
 
 /*
 [
@@ -57,7 +41,7 @@ const Home: React.FC<IHome> = ({ navigation }) => {
 
 */
 
-  console.log(isLoaded)
+  // console.log(isLoaded)
 // console.log(data)
 
 
@@ -65,11 +49,9 @@ const Home: React.FC<IHome> = ({ navigation }) => {
   return (
     <SafeAreaView style={styles.container}>
       <Search/>
-      <Text>This is the homepage</Text>
-      <TouchableOpacity onPress={goToSpotDetail}>
-        <Text>Go to SpotDetail</Text>
-      </TouchableOpacity>
-      <Image style={{ width: 400, height: 400, objectFit: 'contain' }} source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}} />
+      {/* <Text>This is the homepage</Text> */}
+      <Spots navigation={navigation}/>
+      {/* <Image style={{ width: 400, height: 400, objectFit: 'contain' }} source={{ uri: "https://harbr.de/fileadmin/_processed_/a/1/csm_harbr_boardinghouse_ludwigsburg_apartment_comfort_02_8fdc0763bd.jpg"}} /> */}
       <BottomTabs navigation={navigation}/>
     </SafeAreaView>
   );

--- a/mobile/screens/Home/Home.tsx
+++ b/mobile/screens/Home/Home.tsx
@@ -1,9 +1,11 @@
 import React, {useEffect, useState} from 'react';
-import { Text, SafeAreaView, StyleSheet, View, Image } from 'react-native';
-import { ScrollView, TouchableOpacity } from 'react-native-gesture-handler';
+import { Text, SafeAreaView, StyleSheet, Image } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { fetchSpots } from '../../store/spots';
 import BottomTabs from './Components/NavBar';
+import Search from './Components/Search';
+
 // import pineapple from '../../assets/images/pineapple.jpg'
 
 interface IHome {
@@ -62,6 +64,7 @@ const Home: React.FC<IHome> = ({ navigation }) => {
 
   return (
     <SafeAreaView style={styles.container}>
+      <Search/>
       <Text>This is the homepage</Text>
       <TouchableOpacity onPress={goToSpotDetail}>
         <Text>Go to SpotDetail</Text>


### PR DESCRIPTION
**Completed:**
- Created and styled components such as _Search_, _Spots_, and _SpotDetails_ to import into the _Home_ screen
  - All spots are rendered on the screen with details of each spot
  - Used pressable components to create the search bar, filter button, and favorite button(adds spot to wishlist)
 
**In Progress:**
- [ ] Implement infinite scroll to Explore/Home screen
- [ ] Having a user redirected to a spot's detail page when a spot is pressed
- [ ] Add functionality to the pressable components listed above
- [ ] Randomize the availability date ranges for each spot